### PR TITLE
Don't use bare except

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -45,7 +45,7 @@ api = tweepy.API(auth)
 try:
     api.verify_credentials()
     print('Authentication Successful')
-except:
+except Exception:
     print('Authentication Error')
 
 # get the user_id from twitch user
@@ -59,7 +59,7 @@ try:
     currentGame = stream['data'][0]['game_name']
     currentTitle = stream['data'][0]['title']
     online = True
-except:
+except Exception:
     online = False
 
 # functions callbacks
@@ -81,7 +81,7 @@ async def stream_offline(data: dict):
     if len(gamesPlayed) > 0:
         try:
             date = dateStream()
-        except:
+        except Exception:
             return
         status = f"[{date['day']}/{date['month']}/{date[year]}] Games Jogados:\n\n"
         for game in gamesPlayed:
@@ -110,7 +110,7 @@ async def channel_update(data: dict):
                 api.update_status(f'Cellbit está jogando: {game}')
             else: 
                 api.update_status_with_media(f'Cellbit está jogando: {game}\nTempo no VOD: {h}h {m}m {s}s', 'gameImg.jpg')
-        except:
+        except Exception:
             api.update_status(f'Cellbit está jogando: {game}\nTempo no VOD: {h}h {m}m {s}s')
         finally:
             gamesBlacklist = ('Just Chatting', 'Watch Parties')


### PR DESCRIPTION
Bare excepts are bad because they can catch [BareException](https://docs.python.org/3/library/exceptions.html#BaseException)s, which you usually don't want to catch. Catching [Exception](https://docs.python.org/3/library/exceptions.html#Exception) is enough to fix this, but a more specific one would be better.